### PR TITLE
 Fixed java.lang.NumberFormatException: For input string: "xxx"

### DIFF
--- a/library/src/main/java/com/jaredrummler/android/colorpicker/ColorPickerDialog.java
+++ b/library/src/main/java/com/jaredrummler/android/colorpicker/ColorPickerDialog.java
@@ -81,7 +81,7 @@ public class ColorPickerDialog extends DialogFragment implements OnTouchListener
   private static final String ARG_PRESETS_BUTTON_TEXT = "presetsButtonText";
   private static final String ARG_CUSTOM_BUTTON_TEXT = "customButtonText";
   private static final String ARG_SELECTED_BUTTON_TEXT = "selectedButtonText";
-
+  private static final String REGEX = "[^0-9^a-fA-F]";
   public static final int TYPE_CUSTOM = 0;
   public static final int TYPE_PRESETS = 1;
 
@@ -370,7 +370,12 @@ public class ColorPickerDialog extends DialogFragment implements OnTouchListener
 
   @Override public void afterTextChanged(Editable s) {
     if (hexEditText.isFocused()) {
-      int color = parseColorString(s.toString());
+      String colorString = s.toString();
+      if(colorString.matches(REGEX)){
+        hexEditText.setText(colorString.replaceAll(REGEX, ""));
+        return;
+      }
+      int color = parseColorString(colorString);
       if (color != colorPicker.getColor()) {
         fromEditText = true;
         colorPicker.setColor(color, true);


### PR DESCRIPTION
android:digits="0123456789ABCDEFabcdef" not working in some third party input method. use String#replaceAll() for a workaround.
```
Process Name: 'com.example.countdown'
Thread Name: 'main'
Back traces starts.
java.lang.NumberFormatException: For input string: "反推"
	at java.lang.Integer.parseInt(Integer.java:608)
	at com.jaredrummler.android.colorpicker.ColorPickerDialog.parseColorString(ColorPickerDialog.java:398)
	at com.jaredrummler.android.colorpicker.ColorPickerDialog.afterTextChanged(ColorPickerDialog.java:354)
	at android.widget.TextView.sendAfterTextChanged(TextView.java:9444)
	at android.widget.TextView$ChangeWatcher.afterTextChanged(TextView.java:12203)
	at android.text.SpannableStringBuilder.sendAfterTextChanged(SpannableStringBuilder.java:1262)
	at android.text.SpannableStringBuilder.replace(SpannableStringBuilder.java:574)
	at androidx.emoji2.text.SpannableBuilder.replace(SpannableBuilder.java:314)
	at android.text.SpannableStringBuilder.replace(SpannableStringBuilder.java:504)
	at androidx.emoji2.text.SpannableBuilder.replace(SpannableBuilder.java:304)
	at androidx.emoji2.text.SpannableBuilder.replace(SpannableBuilder.java:48)
	at android.view.inputmethod.BaseInputConnection.replaceText(BaseInputConnection.java:863)
	at android.view.inputmethod.BaseInputConnection.commitText(BaseInputConnection.java:208)
	at com.android.internal.widget.EditableInputConnection.commitText(EditableInputConnection.java:187)
```